### PR TITLE
Error con los retornos de carros ('\r')

### DIFF
--- a/infosecmachines.sh
+++ b/infosecmachines.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+nombre_script=$0
+dos2unix $nombre_script &>/dev/null 
+
 # Colours
 greenColour="\e[0;32m\033[1m"
 endColour="\033[0m\e[0m"


### PR DESCRIPTION
Buenas, al ejecutar el script al principio podría aparecerte este error en función de tu distribución:

![image](https://github.com/n0m3l4c000nt35/infosecmachines/assets/128630899/41ac8ec5-6131-4481-98e2-9d37b7847d28)

Ejecutando el comando `dos2unix infosecmachines.sh` se conseguiría arreglar. Por lo que añadiendo las siguientes líneas el propio script se encargaría de esto y sería más cómodo a la hora de ejecutar el script por primera vez.